### PR TITLE
To get consistent chi2 and chi2_prior with action=4

### DIFF
--- a/source/BaseParameters.f90
+++ b/source/BaseParameters.f90
@@ -170,13 +170,13 @@
     allocate(this%GaussPriors%mean(num_params))
     this%GaussPriors%std=0 !no priors by default
     do i=1,num_params
-        if (this%varying(i)) then
+    !jv-    if (this%varying(i)) then
             InLine =  this%NameMapping%ReadIniForParam(Ini,'prior',i)
             if (InLine/='') then
                 read(InLine, *, iostat=status) this%GaussPriors%mean(i), this%GaussPriors%std(i)
                 if (status/=0) call this%ParamError('Error reading prior mean and stdd dev: '//trim(InLIne),i)
             end if
-        end if
+    !jv-    end if
     end do
 
     call Ini%TagValuesForName('linear_combination', Combs)

--- a/source/calclike.f90
+++ b/source/calclike.f90
@@ -116,7 +116,8 @@
 
     logLike=0
     do i=1,num_params
-        if (BaseParams%varying(i) .and. BaseParams%GaussPriors%std(i)/=0) then
+        !jv- if (BaseParams%varying(i) .and. BaseParams%GaussPriors%std(i)/=0) then   
+        if (BaseParams%GaussPriors%std(i)/=0) then
             logLike = logLike + ((P(i)-BaseParams%GaussPriors%mean(i))/BaseParams%GaussPriors%std(i))**2
         end if
     end do


### PR DESCRIPTION
When using action=4 (test likelihoods and produce C_ell) or action=2 (minimizer), one gets inconsistent total chi2 and chi2_prior, if demanding BaseParams%varying(i)=T or this%varying(i)=T as was in the previous versions of the code. Think of a situation where one wants, e.g., to use minimizer with a fixed Planck calibration (cal0) and to compare to a situation where cal0 is varied (and a gaussian prior imposed on it). Another example: one wants to  check that the code really used the reported parameters in MCMC or that there was no openMP mess-up in CAMB during the MCMC run. So, one picks a random sample from an MCMC chain and wants to reproduce its chi2 with action=4. The requested modifications allow for this produce a consistent chi2 compared to the full MCMC. (Earlier versions of the code added only those gaussian priors that were combinations of more than one parameters, while ignoring all single-parameter gaussian priors.) The modifications do create a minimal overhead in MCMC runs in those cases where some parameters are fixed, but at least this way one gets a consistent chi2 no matter what action one uses.