### PR TITLE
This fixes memory problem on some machines

### DIFF
--- a/source/CMBlikes.f90
+++ b/source/CMBlikes.f90
@@ -1189,7 +1189,7 @@
 
     call this%GetTheoryMapCls(Theory, TheoryCls, DataParams)
 
-    !$OMP PARALLEL DO DEFAULT(SHARED),PRIVATE(i,j,C,vecp), reduction(+:chisq)
+    !$OMP PARALLEL DO DEFAULT(SHARED),PRIVATE(i,j), FIRSTPRIVATE(C,vecp), reduction(+:chisq)
     do bin = this%bin_min, this%bin_max
         if (this%binned .or. bin_test) then
             if (this%like_approx == like_approx_fullsky_exact) call mpiStop('CMBLikes: exact like cannot be binned!')

--- a/source/wl.f90
+++ b/source/wl.f90
@@ -571,7 +571,7 @@
         end do
     end do
     !$OMP END PARALLEL DO
-    !$OMP PARALLEL DO DEFAULT(SHARED), PRIVATE(fac, i)
+    !$OMP PARALLEL DO DEFAULT(SHARED), PRIVATE(i), FIRSTPRIVATE(fac)
     do b = 1, this%num_z_bins
         fac = dchis*n_chi(:,b)
         do i=1, this%num_z_p
@@ -602,7 +602,7 @@
     cl_cross=0
 
     fac = dchis/chis**2
-    !$OMP PARALLEL DO DEFAULT(SHARED), PRIVATE(j,kh, type_ix, tp, f1, f2, cltmp, ii, ix, kharr, zarr, powers, wpowers, mwpowers, tmp, wtmp, mwtmp)
+    !$OMP PARALLEL DO DEFAULT(SHARED), PRIVATE(j,kh, type_ix, tp, f1, f2, cltmp, ii, ix), FIRSTPRIVATE(kharr, zarr, powers, wpowers, mwpowers, tmp, wtmp, mwtmp )
     do i=1, size(this%ls_cl)
         ix =0
         do j = 1, this%num_z_p


### PR DESCRIPTION
I had a problem with a mysterious segfault on a cluster. I traced it back with a debugger to these two variables that were declared as private. Since their shape is resolved at run time they are not guaranteed to be copied in the OMP section. Firstprivate forces the initial copy and solves the problem.