### PR TITLE
Fix to deallocation if the first mcmc point fails

### DIFF
--- a/source/Calculator_CAMB.f90
+++ b/source/Calculator_CAMB.f90
@@ -976,7 +976,7 @@
     class(TCalculationAtParamPoint), target :: Params
 
     if (.not. associated(Params%Info)) then
-        Params%Info =>this%DefaultInstance
+        allocate(Params%Info, source=this%DefaultInstance)
     end if
 
     select type(Info=>Params%Info)


### PR DESCRIPTION
If the first try in the mcmc does not succeed, i.e. H0 is out of bound, then the code crashes saying that this%Info cannot be deallocated (possibly because it was never allocated in the first place).
Putting a dummy status check solves the problem and does not seem to be harmful.